### PR TITLE
fix: 🐛 compatibility with webworker

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ const reactNativeWeb = (/*options: ViteReactNativeWebOptions = {}*/): VitePlugin
 
     config: () => ({
         define: {
-            global: 'window',
+            global: 'self',
             __DEV__: JSON.stringify(development),
             'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
         },


### PR DESCRIPTION
This plugin breaks web worker as it adds in env.mjs a reference to window.

Using "self" is more robust and allows to use it with web workers (https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers#web_workers_api)